### PR TITLE
feat: (RQRCode) Modify the color of the QR code copy to make it clearer

### DIFF
--- a/src/components/RQRCode/src/index.scss
+++ b/src/components/RQRCode/src/index.scss
@@ -22,5 +22,24 @@
       font-weight: 500;
       color: #ffffff;
     }
+
+    & .ray-qrcode__error-btn {
+      .ray-icon,
+      .n-button__content {
+        color: #fff;
+      }
+      .n-button:hover {
+        .ray-icon,
+        .n-button__content {
+          color: var(--n-text-color-hover);
+        }
+      }
+      .n-button:active {
+        .ray-icon,
+        .n-button__content {
+          color: var(--n-text-color-pressed);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
The text color conflicts with the background color

There are two solutions
1. Modify text color
2. Add a background mask layer
3. Use filter: invert(100%); or mix-blend-mode: difference; but you will still encounter the problem that neutral colors cannot be recognized.